### PR TITLE
Bugfix Rsschool cv html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ru">
 <head>
-  <meta charset="utf-8" />
-  <title></title>
-  <link rel="stylesheet" href="style.css" />
+  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+  <title>rsschool-cv</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
  ...    


### PR DESCRIPTION
Failed HTML requirements.
 - DOCTYPE should be uppercase 
 - Expected omitted end tag <meta> instead of self-closing element <meta/> 
 - <title> cannot be empty, must have text content 
 - Expected omitted end tag <link> instead of self-closing element <link/> 
 - Trailing whitespace
